### PR TITLE
Add new java client library for google-api-client HTTP client

### DIFF
--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -8,13 +8,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>swagger-codegen-cli</artifactId>
+    <artifactId>swagger-codegen-premise-cli</artifactId>
     <packaging>jar</packaging>
 
     <name>swagger-codegen (executable)</name>
 
     <build>
-        <finalName>swagger-codegen-cli</finalName>
+        <finalName>swagger-codegen-premise-cli</finalName>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/Java/libraries/jersey2/ApiClient.mustache
@@ -56,21 +56,21 @@ import {{invokerPackage}}.auth.OAuth;
 
 {{>generatedAnnotation}}
 public class ApiClient {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "{{{basePath}}}";
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected String basePath = "{{{basePath}}}";
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private Client httpClient;
-  private JSON json;
-  private String tempFolderPath = null;
+  protected Client httpClient;
+  protected JSON json;
+  protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     json = new JSON();
@@ -740,7 +740,7 @@ public class ApiClient {
    * @param debugging Debug setting
    * @return Client
    */
-  private Client buildHttpClient(boolean debugging) {
+  protected Client buildHttpClient(boolean debugging) {
     final ClientConfig clientConfig = new ClientConfig();
     clientConfig.register(MultiPartFeature.class);
     clientConfig.register(json);
@@ -748,10 +748,15 @@ public class ApiClient {
     if (debugging) {
       clientConfig.register(new LoggingFilter(java.util.logging.Logger.getLogger(LoggingFilter.class.getName()), true));
     }
+    performAdditionalClientConfiguration(clientConfig);
     return ClientBuilder.newClient(clientConfig);
   }
 
-  private Map<String, List<String>> buildResponseHeaders(Response response) {
+  protected void performAdditionalClientConfiguration(ClientConfig clientConfig) {
+    // No-op extension point
+  }
+
+  protected Map<String, List<String>> buildResponseHeaders(Response response) {
     Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
@@ -769,7 +774,7 @@ public class ApiClient {
    *
    * @param authNames The authentications to apply
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,18 @@
     <name>swagger-codegen-project</name>
     <version>2.3.0-SNAPSHOT</version>
     <url>https://github.com/swagger-api/swagger-codegen</url>
+
+    <distributionManagement>
+        <repository>
+            <id>internal-releases</id>
+            <url>https://premise.jfrog.io/premise/private-local</url>
+        </repository>
+        <snapshotRepository>
+            <id>internal-snapshots</id>
+            <url>https://premise.jfrog.io/premise/private-snapshots-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-codegen.git</connection>
         <developerConnection>scm:git:git@github.com:swagger-api/swagger-codegen.git</developerConnection>

--- a/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2-java6/src/main/java/io/swagger/client/ApiClient.java
@@ -50,21 +50,21 @@ import io.swagger.client.auth.OAuth;
 
 
 public class ApiClient {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io:80/v2";
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected String basePath = "http://petstore.swagger.io:80/v2";
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private Client httpClient;
-  private JSON json;
-  private String tempFolderPath = null;
+  protected Client httpClient;
+  protected JSON json;
+  protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     json = new JSON();
@@ -729,7 +729,7 @@ public class ApiClient {
    * @param debugging Debug setting
    * @return Client
    */
-  private Client buildHttpClient(boolean debugging) {
+  protected Client buildHttpClient(boolean debugging) {
     final ClientConfig clientConfig = new ClientConfig();
     clientConfig.register(MultiPartFeature.class);
     clientConfig.register(json);
@@ -737,10 +737,15 @@ public class ApiClient {
     if (debugging) {
       clientConfig.register(new LoggingFilter(java.util.logging.Logger.getLogger(LoggingFilter.class.getName()), true));
     }
+    performAdditionalClientConfiguration(clientConfig);
     return ClientBuilder.newClient(clientConfig);
   }
 
-  private Map<String, List<String>> buildResponseHeaders(Response response) {
+  protected void performAdditionalClientConfiguration(ClientConfig clientConfig) {
+    // No-op extension point
+  }
+
+  protected Map<String, List<String>> buildResponseHeaders(Response response) {
     Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
@@ -758,7 +763,7 @@ public class ApiClient {
    *
    * @param authNames The authentications to apply
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);

--- a/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
+++ b/samples/client/petstore/java/jersey2/src/main/java/io/swagger/client/ApiClient.java
@@ -51,21 +51,21 @@ import io.swagger.client.auth.OAuth;
 
 
 public class ApiClient {
-  private Map<String, String> defaultHeaderMap = new HashMap<String, String>();
-  private String basePath = "http://petstore.swagger.io:80/v2";
-  private boolean debugging = false;
-  private int connectionTimeout = 0;
+  protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
+  protected String basePath = "http://petstore.swagger.io:80/v2";
+  protected boolean debugging = false;
+  protected int connectionTimeout = 0;
 
-  private Client httpClient;
-  private JSON json;
-  private String tempFolderPath = null;
+  protected Client httpClient;
+  protected JSON json;
+  protected String tempFolderPath = null;
 
-  private Map<String, Authentication> authentications;
+  protected Map<String, Authentication> authentications;
 
-  private int statusCode;
-  private Map<String, List<String>> responseHeaders;
+  protected int statusCode;
+  protected Map<String, List<String>> responseHeaders;
 
-  private DateFormat dateFormat;
+  protected DateFormat dateFormat;
 
   public ApiClient() {
     json = new JSON();
@@ -729,7 +729,7 @@ public class ApiClient {
    * @param debugging Debug setting
    * @return Client
    */
-  private Client buildHttpClient(boolean debugging) {
+  protected Client buildHttpClient(boolean debugging) {
     final ClientConfig clientConfig = new ClientConfig();
     clientConfig.register(MultiPartFeature.class);
     clientConfig.register(json);
@@ -737,10 +737,15 @@ public class ApiClient {
     if (debugging) {
       clientConfig.register(new LoggingFilter(java.util.logging.Logger.getLogger(LoggingFilter.class.getName()), true));
     }
+    performAdditionalClientConfiguration(clientConfig);
     return ClientBuilder.newClient(clientConfig);
   }
 
-  private Map<String, List<String>> buildResponseHeaders(Response response) {
+  protected void performAdditionalClientConfiguration(ClientConfig clientConfig) {
+    // No-op extension point
+  }
+
+  protected Map<String, List<String>> buildResponseHeaders(Response response) {
     Map<String, List<String>> responseHeaders = new HashMap<String, List<String>>();
     for (Entry<String, List<Object>> entry: response.getHeaders().entrySet()) {
       List<Object> values = entry.getValue();
@@ -758,7 +763,7 @@ public class ApiClient {
    *
    * @param authNames The authentications to apply
    */
-  private void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams) {
+  protected void updateParamsForAuth(String[] authNames, List<Pair> queryParams, Map<String, String> headerParams) {
     for (String authName : authNames) {
       Authentication auth = authentications.get(authName);
       if (auth == null) throw new RuntimeException("Authentication undefined: " + authName);


### PR DESCRIPTION
### PR checklist
(This isn't a PR to the main swagger-codegen repo, so I'm eschewing process for now). After testing this, I'll put up a PR with the main `swagger-codegen` project.

### Description of the PR

Add a new `library` type you can use to generate clients based on the Google `google-api-client` HTTP client library. It generates an `ApiClient` class that has a nice builder pattern for accessing your APIs. It uses the `com.google.api.client.http.HttpRequestFactory` to make HTTP requests. 

Some configuration options include:
* The base path 
* an `HttpRequestInitializer` (which can be any `Credential` object to provide authentication, or a combination of credentials plus any other way you want to initialize requests).
* the `ObjectMapper` you want to use for reading/writing request bodies.
* The `HttpTransport`
